### PR TITLE
Allows SideNavBarItem to render children

### DIFF
--- a/src/components/SideNavBar/SideNavBarItem.jsx
+++ b/src/components/SideNavBar/SideNavBarItem.jsx
@@ -9,6 +9,14 @@ class SideNavBarItem extends React.Component {
         onClick={this.props.onClick}
       >
         {this.props.selected && <div className={style.itemWrapperSelected} />}
+        { this.props.children || this.renderIconAndLabel() }
+      </div>
+    );
+  }
+
+  renderIconAndLabel() {
+    return (
+      <div>
         <img
           className={style.icon}
           style={{
@@ -21,7 +29,7 @@ class SideNavBarItem extends React.Component {
         />
         <div className={style.label}>{this.props.label}</div>
       </div>
-    );
+    )
   }
 }
 
@@ -45,6 +53,7 @@ SideNavBarItem.propTypes = {
   label: React.PropTypes.string,
   onClick: React.PropTypes.func,
   selected: React.PropTypes.bool,
+  children: React.PropTypes.node,
 };
 
 SideNavBarItem.displayName = 'SideNavBarItem';


### PR DESCRIPTION
I wanted to render an SVG instead of using an imageUrl.

Figured this was a sensible way to accomplish this - if the component has children it renders those instead of the icon and label.
