### PR TITLE
removes empty label style from button

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -31,7 +31,7 @@ class Button extends React.Component {
         className={cx(style.button, buttonStyle)}
         onClick={this.props.onClick}
       >
-        <div className={style.label}>{this.props.label}</div>
+        {this.props.label}
       </div>
     );
   }

--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -14,7 +14,7 @@
 }
 
 .tertiary {
-  
+
 }
 
 .disabled {
@@ -25,8 +25,4 @@
     background: $cButtonDisabledBg;
     color: $cButtonDisabledLabel;
   }
-}
-
-.label {
-  
 }


### PR DESCRIPTION
Fixes this issue where a multiword button had its words on top of one another:

![screen shot 2016-11-03 at 5 29 09 pm](https://cloud.githubusercontent.com/assets/923033/19986339/aa7e1528-a1ec-11e6-8ff3-4b2155cdb59e.png)

tbh I'd actually really like the button to just render children. idk, passing the label as a prop is kinda strange to me. and then what about when we want to do like an icon button?

happy to go ahead and make / propose those changes, but lmkwyt