### PR TITLE
update styling of SideNavBarItems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wework-dev/plasma",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/components/SideNavBar/SideNavBarItem.jsx
+++ b/src/components/SideNavBar/SideNavBarItem.jsx
@@ -1,35 +1,47 @@
 import React from 'react';
-
+import cn from 'classnames';
 import Base from '../Base.jsx';
 import style from './style.scss';
 
 class SideNavBarItem extends React.Component {
   render() {
+    const { children, darkBg, onClick, selected } = this.props;
+
+    const wrapperClasses = cn(style.itemWrapper, {
+      [style.darkBg]: darkBg,
+      [style.selected]: selected,
+    });
+
     return (
       <div
-        className={style.itemWrapper}
-        onClick={this.props.onClick}
+        className={wrapperClasses}
+        onClick={onClick}
       >
-        {this.props.selected && <div className={style.itemWrapperSelected} />}
-        { this.props.children || this.renderIconAndLabel() }
+        { children || this.renderIconAndLabel() }
       </div>
     );
   }
 
   renderIconAndLabel() {
+    const { icon, iconSize, iconStyle, label } = this.props;
+
+    const renderIcon = icon && iconSize && (
+      <img
+        className={style.icon}
+        style={{
+          width: iconSize,
+          height: iconSize,
+          ...iconStyle,
+        }}
+        src={icon}
+        alt={label}
+      />
+    );
+
     return (
       <div>
-        <img
-          className={style.icon}
-          style={{
-            width: this.props.iconSize,
-            height: this.props.iconSize,
-            ...this.props.iconStyle,
-          }}
-          src={this.props.icon}
-          alt={this.props.label}
-        />
-        <div className={style.label}>{this.props.label}</div>
+        {renderIcon}
+        <div className={style.label}>{label}</div>
       </div>
     )
   }

--- a/src/components/SideNavBar/style.scss
+++ b/src/components/SideNavBar/style.scss
@@ -31,7 +31,7 @@
   border-bottom: 1px solid rgba(0,0,0,0.3);
   transition: all 0.3s;
 
-  &:hover, &:active {
+  &:hover, &:active, &:focus {
     background: $cPurple200;
   }
 

--- a/src/components/SideNavBar/style.scss
+++ b/src/components/SideNavBar/style.scss
@@ -30,11 +30,8 @@
   position: relative;
   border-bottom: 1px solid rgba(0,0,0,0.3);
   transition: all 0.3s;
-  &:hover {
-    background: $cPurple200;
-  }
 
-  &:active {
+  &:hover, &:active {
     background: $cPurple200;
   }
 

--- a/src/components/SideNavBar/style.scss
+++ b/src/components/SideNavBar/style.scss
@@ -31,24 +31,23 @@
   border-bottom: 1px solid rgba(0,0,0,0.3);
   transition: all 0.3s;
   &:hover {
-    background: darken($cPurple100, 5%);
+    background: $cPurple200;
   }
+
   &:active {
-    background: darken($cPurple100, 10%);
+    background: $cPurple200;
   }
+
   .icon {
     margin-bottom: 5px;
   }
-  .label {
-    
-  }
 }
 
-.itemWrapperSelected {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 5px;
-  background-color: $cPurple200;
+.darkBg {
+  background: fade-out(#000, 0.9);
+}
+
+.selected {
+  background: fade-out($cPurple200, 0.9);
+  border-left: 5px solid $cPurple200;
 }

--- a/stories/SideNavBar.js
+++ b/stories/SideNavBar.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import _ from 'lodash';
+import { storiesOf } from '@kadira/storybook';
+import Image from '../src/components/Image/Image';
+import SideNavBar from '../src/components/SideNavBar/SideNavBar';
+import SideNavBarItem from '../src/components/SideNavBar/SideNavBarItem';
+
+storiesOf('SideNavBar', module).add('default', () => {
+  return (
+    <SideNavBar>
+      <Image
+        style={{ width: 50, height: 'auto', marginBottom: 16 }}
+        src="http://spacestation.wework.com/images/weworkLight.svg"
+      />
+      <div style={{ display: 'block', width: '100%' }}>
+        <SideNavBarItem
+          label="Dark Bg"
+          onClick={() => {}}
+          selected={false}
+          darkBg
+        />
+        <SideNavBarItem
+          icon="http://placehold.it/24x24"
+          label="Label 1"
+          onClick={() => {}}
+          selected={false}
+        />
+        <SideNavBarItem
+          icon="http://placehold.it/24x24"
+          label="Label 2"
+          onClick={() => {}}
+          selected
+        />
+        <SideNavBarItem
+          icon="http://placehold.it/24x24"
+          label="Label 3"
+          onClick={() => {}}
+          selected={false}
+        />
+        <SideNavBarItem
+          icon="http://placehold.it/24x24"
+          label="Label 4"
+          onClick={() => {}}
+          selected={false}
+        />
+      </div>
+    </SideNavBar>
+  );
+});

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,3 +6,4 @@ import FormField from './FormField';
 import Label from './Label';
 import TextInput from './TextInput';
 import Table from './Table';
+import SideNavBar from './SideNavBar';


### PR DESCRIPTION
Now we have the option to pass in a prop for a "dark background" (ie. for the search component in Plasma guide... or for the story I'm working on: the current location)
![screen shot 2017-04-17 at 5 29 40 pm](https://cloud.githubusercontent.com/assets/1829422/25105635/7e2e44e2-2393-11e7-896f-a5959d893026.png)

New hover state too:
![screen shot 2017-04-17 at 5 32 39 pm](https://cloud.githubusercontent.com/assets/1829422/25105745/f586d3d8-2393-11e7-832c-7482e753623c.png)



For https://github.com/WeConnect/spacestation-v2/pull/921