### PR TITLE
Fix Unknown prop `description` on <input> tag console warning

### DIFF
--- a/src/components/RadioButton/RadioButton.jsx
+++ b/src/components/RadioButton/RadioButton.jsx
@@ -21,7 +21,6 @@ class RadioButton extends React.Component {
             type="radio"
             id={id}
             name={this.props.name}
-            description={this.props.description}
             onChange={this.props.onChange}
             checked={this.props.checked}
           />


### PR DESCRIPTION
This fixes a prop warning on the RadioButton component.. description is not a valid prop for input.