### PR TITLE
Use value attribute for radio button

### DIFF
--- a/src/components/RadioButton/RadioButton.jsx
+++ b/src/components/RadioButton/RadioButton.jsx
@@ -27,6 +27,7 @@ class RadioButton extends React.Component {
             name={this.props.name}
             onChange={this.props.onChange}
             checked={this.props.checked}
+            value={this.props.val}
           />
           <div className={style.faux} />
           <div className={style.text}>


### PR DESCRIPTION
The `RadioButton` component does not currently set a `value` attribute on the underlying `input` element. This makes it difficult to use the `onChange` handler.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio)

```If you omit the value attribute in the HTML, the submitted form data assigns the value "on" to the group. In this scenario, if the user clicked on the "Phone" option and submitted the form, the resulting form data would be "contact=on", which isn't helpful. So don't forget to set your value attributes!```