### PR TITLE
DMX-4218 Plasma Checkbox fixes

### DIFF
--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -24,13 +24,11 @@ class Checkbox extends React.Component {
     } = this.props;
     const id = uniqueId('id');
     const inputClassName = indeterminate ? style.indeterminate : style.original;
-    const wrapperClassName = cx({
-      [style.wrapper]: !disabled,
+    const wrapperClassName = cx(style.wrapper, {
       [style.wrapperDisabled]: disabled,
     });
-    const textClassName = cx({
+    const textClassName = cx(style.text, {
       [style.textBold]: isBold,
-      [style.text]: !disabled,
       [style.textDisabled]: disabled,
     });
 

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -1,6 +1,7 @@
 import { uniqueId } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import style from './style.scss';
 import {
   getDataAttrs,
@@ -11,6 +12,7 @@ class Checkbox extends React.Component {
 
   render() {
     const {
+      isBold,
       checked,
       indeterminate,
       name,
@@ -22,29 +24,40 @@ class Checkbox extends React.Component {
     } = this.props;
     const id = uniqueId('id');
     const inputClassName = indeterminate ? style.indeterminate : style.original;
+    const wrapperClassName = cx({
+      [style.wrapper]: !disabled,
+      [style.wrapperDisabled]: disabled
+    });
+    const textClassName = cx({
+      [style.textBold]: isBold,
+      [style.text]: !disabled,
+      [style.textDisabled]: disabled
+    });
 
     return (
       <div
         {...getDataAttrs(data)}
       >
-        <label
-          htmlFor={id}
-          className={style.wrapper}
-        >
-          <input
-            disabled={disabled}
-            checked={checked || value}
-            className={inputClassName}
-            type="checkbox"
-            id={id}
-            name={name}
-            onChange={onChange}
-          />
-          <div className={style.checkbox} />
-          <div className={style.text}>
-            {text}
-          </div>
-        </label>
+        <div>
+          <label
+            htmlFor={id}
+            className={wrapperClassName}
+          >
+            <input
+              disabled={disabled}
+              checked={checked || value}
+              className={inputClassName}
+              type="checkbox"
+              id={id}
+              name={name}
+              onChange={onChange}
+            />
+            <div className={style.checkbox} />
+            <div className={textClassName}>
+              {text}
+            </div>
+          </label>
+        </div>
         { this.props.description &&
           <span className={style.description}>
             { this.props.description }

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -26,12 +26,12 @@ class Checkbox extends React.Component {
     const inputClassName = indeterminate ? style.indeterminate : style.original;
     const wrapperClassName = cx({
       [style.wrapper]: !disabled,
-      [style.wrapperDisabled]: disabled
+      [style.wrapperDisabled]: disabled,
     });
     const textClassName = cx({
       [style.textBold]: isBold,
       [style.text]: !disabled,
-      [style.textDisabled]: disabled
+      [style.textDisabled]: disabled,
     });
 
     return (

--- a/src/components/Checkbox/style.scss
+++ b/src/components/Checkbox/style.scss
@@ -1,16 +1,16 @@
 @import '../../styles/base';
+$checkboxBorder: 1px solid $cBorder;
 
-.wrapperBase {
+.wrapper {
   position: relative;
   display: inline-flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
   cursor: pointer;
-}
-
-.wrapper {
-  composes: wrapperBase;
+  .original, .intermediate {
+    cursor: pointer;
+  }
   &:hover {
     .checkbox {
       border: 1px solid $cGray200;
@@ -19,10 +19,14 @@
 }
 
 .wrapperDisabled {
-  composes: wrapperBase;
   cursor: not-allowed;
   .original, .indeterminate {
     cursor: not-allowed;
+  }
+  &:hover {
+    .checkbox {
+      border: $checkboxBorder;
+    }
   }
 }
 
@@ -31,7 +35,6 @@
   position: absolute;
   opacity: 0;
   z-index: 10;
-  cursor: pointer;
   ~ .checkbox::before {
     width: 12px;
     height: 8px;
@@ -51,7 +54,6 @@
   position: absolute;
   opacity: 0;
   z-index: 10;
-  cursor: pointer;
 
   ~ .checkbox::before {
     content: '';
@@ -74,7 +76,7 @@
   width: 16px;
   height: 16px;
   background: $cWhite;
-  border: 1px solid $cBorder;
+  border: $checkboxBorder;
   border-radius: 3px;
   background: $cWhite;
   transition: border-color 0.1s ease-out;
@@ -89,14 +91,9 @@
   }
 }
 
-.textBase {
+.text {
   margin-left: 10px;
   @extend %type--body;
-}
-
-.text {
-  composes: textBase;
-  cursor: pointer;
 }
 
 .textBold {
@@ -104,7 +101,6 @@
 }
 
 .textDisabled {
-  composes: textBase;
   color: $cGray200;
 }
 

--- a/src/components/Checkbox/style.scss
+++ b/src/components/Checkbox/style.scss
@@ -1,12 +1,16 @@
 @import '../../styles/base';
 
-.wrapper {
+.wrapperBase {
   position: relative;
-  display: flex;
+  display: inline-flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
   cursor: pointer;
+}
+
+.wrapper {
+  composes: wrapperBase;
   &:hover {
     .checkbox {
       border: 1px solid $cGray200;
@@ -14,14 +18,29 @@
   }
 }
 
+.wrapperDisabled {
+  composes: wrapperBase;
+  cursor: not-allowed;
+  .original, .indeterminate {
+    cursor: not-allowed;
+  }
+}
+
+
 .original {
   position: absolute;
   opacity: 0;
   z-index: 10;
   cursor: pointer;
+  ~ .checkbox::before {
+    width: 12px;
+    height: 8px;
+    content: '';
+  }
 
   &:checked ~ .checkbox {
     &::before {
+      height: 20px;
       // content: url('data:image/svg+xml;utf8,<svg width="12px" height="10px" viewBox="2 5 12 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs></defs><polygon id="Rectangle-34" stroke="none" fill="#282829" fill-rule="evenodd" points="6 15 2 10.8333333 3.6 9.16666667 6 11.6666667 12.4 5 14 6.66666667"></polygon></svg>');
       content: url('data:image/svg+xml;utf8,<svg width="12px" height="10px" viewBox="0 0 12 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- Generator: Sketch 43.1 (39012) - http://www.bohemiancoding.com/sketch --><title>checked</title><desc>Created with Sketch.</desc><defs></defs><g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="checkbox-/-selected" transform="translate(-2.000000, -8.000000)" fill="#252729"><polygon id="checked" points="6 18 2 13.8333333 3.6 12.1666667 6 14.6666667 12.4 8 14 9.66666667"></polygon></g></g></svg>');
     }
@@ -33,6 +52,11 @@
   opacity: 0;
   z-index: 10;
   cursor: pointer;
+
+  ~ .checkbox::before {
+    content: '';
+    height: 2px;
+  }
 
   &:checked ~ .checkbox {
     &::before {
@@ -65,10 +89,23 @@
   }
 }
 
-.text {
+.textBase {
   margin-left: 10px;
   @extend %type--body;
+}
+
+.text {
+  composes: textBase;
   cursor: pointer;
+}
+
+.textBold {
+  font-weight: bold;
+}
+
+.textDisabled {
+  composes: textBase;
+  color: $cGray200;
 }
 
 .description {

--- a/src/components/layout/FormField/FormField.jsx
+++ b/src/components/layout/FormField/FormField.jsx
@@ -37,7 +37,6 @@ const FormField = (
     >
       <Label
         text={labelText}
-        type={labelType}
         className={style.disabled}
         type={isDisabled ? 'disabled' : 'primary'}
       />


### PR DESCRIPTION
 We want to use plasma checkbox and allow for disabled look+feel
* Add classnames to Checkbox.jsx
* Add disabled styling for Checkbox.jsx
* Apply inline-flex to label container (and separate from description)
* The description was stretching out the containing div, causing the label's clickable area to be much larger than the text that should be clickable
Also, remove extra declaration for type on FormField's Label

UI changes:
Old Original Checkbox (label clickable-area is way past the text):  
[Original Before click](https://user-images.githubusercontent.com/3250676/32805185-bc494cae-c956-11e7-9767-72a5f1e7fdce.jpeg)
[Original After click](https://user-images.githubusercontent.com/3250676/32805190-bcff0ada-c956-11e7-8b1e-1da2089c00a7.jpeg)
Old Indeterminate Checkbox (label clickable-area is way past the text):  
[Indeterminate Before click](https://user-images.githubusercontent.com/3250676/32805191-bd087bd8-c956-11e7-91ab-a47af9ce0f22.jpeg)
[Indeterminaste After click](https://user-images.githubusercontent.com/3250676/32805192-bd135422-c956-11e7-898a-e96ca7e05f51.jpeg)
New Original Checkbox (note, label clickable area does not extend past the text):  
[plasma dmx-4218 notclickable](https://user-images.githubusercontent.com/3250676/32805193-bd22b43a-c956-11e7-866a-45977f09349a.jpeg)
New Indeterminate Checkbox (note, label clickable area does not extend past the text):  
[plasma dmx-4218 notclickableindeterminate](https://user-images.githubusercontent.com/3250676/32805194-bd3159e0-c956-11e7-985b-4659ca100093.jpeg)

I demonstrate the changes to the indeterminate checkbox as well because I needed to add spacing to the "unchecked" state of the fake checkbox due to the introduction of new elements shifting the position of the label upon check/uncheck.

Also, note that I am able to set the label text to be bold via props - The designs I was given call for a bold label, but I can see why you would want checkboxes to not necessarily have a bold label.

I've also linked two mov files that demonstrate the disabled styling changes:  
[Old Disabled Checkbox Behavior](https://drive.google.com/open?id=1G0Wpx4eNA24URpFqbSdcxLSbRsDDHYyA)
[New Disabled Checkbox Behavior](https://drive.google.com/open?id=1J31gWcaAWQHNtalUutK_uNlE0a2ScyTC)