### PR TITLE
[RFC] Add withCounter option to textarea

### DIFF
--- a/StoryState.js
+++ b/StoryState.js
@@ -1,0 +1,14 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class StoryState extends Component {
+  static propTypes = {
+    render: PropTypes.func.isRequired,
+  };
+
+  state = {};
+
+  render() {
+    return this.props.render(this.state, this.setState.bind(this));
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "WeWork",
   "license": "ISC",
   "devDependencies": {
-    "@storybook/react": "^3.0.0",
     "anchorate": "^1.1.0",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.10.4",
@@ -75,6 +74,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
+    "@storybook/react": "^3.0.0",
     "@storybook/addon-actions": "^3.1.9",
     "@storybook/addon-links": "^3.1.6",
     "babel-runtime": "^6.9.2",

--- a/src/components/TextArea/TextArea.jsx
+++ b/src/components/TextArea/TextArea.jsx
@@ -7,31 +7,19 @@ import Autogrow from './autogrow';
 import style from './style.scss';
 
 class TextArea extends Component {
-  onChange = (...args) => {
-    this.setState({
-      value: this.textarea.value,
-    });
-    return this.props.onChange && this.props.onChange(...args);
-  };
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: this.props.value || '',
-    };
-  }
   render() {
     const {
-      counterStyle,
       data,
       disabled,
       error,
       maxLength,
       onBlur,
+      onChange,
       onFocus,
       placeholder,
       rows,
       size,
-      withCounter,
+      value,
     } = this.props;
 
     const wrapperStyle = cx(style.wrapper, {
@@ -47,18 +35,17 @@ class TextArea extends Component {
 
     return (
       <div>
-        {withCounter && (
-          <div className={counterStyle || style.counterStyle}>
-            {this.state.value.length}
-            {maxLength && `/${maxLength}`} characters
-          </div>
-        )}
         <div className={wrapperStyle} {...getDataAttrs(data)}>
           <textarea
-            ref={el => el && (this.textarea = el) && new Autogrow(el)}
+            ref={el => {
+              if (el && !el.props) {
+                new Autogrow(el);
+                this.props.parentRef && this.props.parentRef(el);
+              }
+            }}
             className={textareaStyle}
             disabled={disabled}
-            onChange={this.onChange}
+            onChange={onChange}
             rows={rows}
             onFocus={e => {
               /* eslint-disable no-param-reassign */
@@ -71,7 +58,7 @@ class TextArea extends Component {
               onBlur && onBlur();
             }}
             placeholder={placeholder}
-            value={this.state.value}
+            value={value}
             maxLength={maxLength}
           />
         </div>
@@ -81,7 +68,6 @@ class TextArea extends Component {
 }
 
 TextArea.propTypes = {
-  counterStyle: PropTypes.object,
   disabled: PropTypes.bool,
   error: PropTypes.bool,
   maxLength: PropTypes.string,
@@ -92,7 +78,6 @@ TextArea.propTypes = {
   rows: PropTypes.string,
   size: PropTypes.string,
   value: PropTypes.string,
-  withCounter: PropTypes.bool,
   ...getDataProps(),
 };
 

--- a/src/components/TextArea/TextArea.jsx
+++ b/src/components/TextArea/TextArea.jsx
@@ -7,56 +7,92 @@ import Autogrow from './autogrow';
 import style from './style.scss';
 
 class TextArea extends Component {
+  onChange = (...args) => {
+    this.setState({
+      value: this.textarea.value,
+    });
+    return this.props.onChange && this.props.onChange(...args);
+  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: this.props.value || '',
+    };
+  }
   render() {
+    const {
+      counterStyle,
+      data,
+      disabled,
+      error,
+      maxLength,
+      onBlur,
+      onFocus,
+      placeholder,
+      rows,
+      size,
+      withCounter,
+    } = this.props;
+
     const wrapperStyle = cx(style.wrapper, {
-      [style.wrapperDisabled]: this.props.disabled,
-      [style.wrapperError]: this.props.error,
-      [style.wrapperLarge]: toUpper(this.props.size) === 'LARGE',
+      [style.wrapperDisabled]: disabled,
+      [style.wrapperError]: error,
+      [style.wrapperLarge]: toUpper(size) === 'LARGE',
     });
 
     const textareaStyle = cx(style.textarea, {
-      [style.disabled]: this.props.disabled,
-      [style.large]: toUpper(this.props.size) === 'LARGE',
+      [style.disabled]: disabled,
+      [style.large]: toUpper(size) === 'LARGE',
     });
 
     return (
-      <div className={wrapperStyle} {...getDataAttrs(this.props.data)}>
-        <textarea
-          ref={el => el && new Autogrow(el)}
-          className={textareaStyle}
-          disabled={this.props.disabled}
-          onChange={this.props.onChange}
-          rows={this.props.rows}
-          onFocus={e => {
-            /* eslint-disable no-param-reassign */
-            e.target.parentElement.className += ` ${style.wrapperFocused}`;
-            /* eslint-enable no-param-reassign */
-            this.props.onFocus && this.props.onFocus();
-          }}
-          onBlur={e => {
-            e.target.parentElement.classList.remove(style.wrapperFocused);
-            this.props.onBlur && this.props.onBlur();
-          }}
-          placeholder={this.props.placeholder}
-          value={this.props.value}
-          maxLength={this.props.maxLength}
-        />
+      <div>
+        {withCounter && (
+          <div className={counterStyle || style.counterStyle}>
+            {this.state.value.length}
+            {maxLength && `/${maxLength}`} characters
+          </div>
+        )}
+        <div className={wrapperStyle} {...getDataAttrs(data)}>
+          <textarea
+            ref={el => el && (this.textarea = el) && new Autogrow(el)}
+            className={textareaStyle}
+            disabled={disabled}
+            onChange={this.onChange}
+            rows={rows}
+            onFocus={e => {
+              /* eslint-disable no-param-reassign */
+              e.target.parentElement.className += ` ${style.wrapperFocused}`;
+              /* eslint-enable no-param-reassign */
+              onFocus && onFocus();
+            }}
+            onBlur={e => {
+              e.target.parentElement.classList.remove(style.wrapperFocused);
+              onBlur && onBlur();
+            }}
+            placeholder={placeholder}
+            value={this.state.value}
+            maxLength={maxLength}
+          />
+        </div>
       </div>
     );
   }
 }
 
 TextArea.propTypes = {
-  placeholder: PropTypes.string,
-  value: PropTypes.string,
-  onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
+  counterStyle: PropTypes.object,
   disabled: PropTypes.bool,
-  size: PropTypes.string,
-  rows: PropTypes.string,
   error: PropTypes.bool,
   maxLength: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  placeholder: PropTypes.string,
+  rows: PropTypes.string,
+  size: PropTypes.string,
+  value: PropTypes.string,
+  withCounter: PropTypes.bool,
   ...getDataProps(),
 };
 

--- a/src/components/TextArea/TextArea.jsx
+++ b/src/components/TextArea/TextArea.jsx
@@ -34,34 +34,32 @@ class TextArea extends Component {
     });
 
     return (
-      <div>
-        <div className={wrapperStyle} {...getDataAttrs(data)}>
-          <textarea
-            ref={el => {
-              if (el && !el.props) {
-                new Autogrow(el);
-                this.props.parentRef && this.props.parentRef(el);
-              }
-            }}
-            className={textareaStyle}
-            disabled={disabled}
-            onChange={onChange}
-            rows={rows}
-            onFocus={e => {
-              /* eslint-disable no-param-reassign */
-              e.target.parentElement.className += ` ${style.wrapperFocused}`;
-              /* eslint-enable no-param-reassign */
-              onFocus && onFocus();
-            }}
-            onBlur={e => {
-              e.target.parentElement.classList.remove(style.wrapperFocused);
-              onBlur && onBlur();
-            }}
-            placeholder={placeholder}
-            value={value}
-            maxLength={maxLength}
-          />
-        </div>
+      <div className={wrapperStyle} {...getDataAttrs(data)}>
+        <textarea
+          ref={el => {
+            if (el && !el.props) {
+              new Autogrow(el);
+              this.props.parentRef && this.props.parentRef(el);
+            }
+          }}
+          className={textareaStyle}
+          disabled={disabled}
+          onChange={onChange}
+          rows={rows}
+          onFocus={e => {
+            /* eslint-disable no-param-reassign */
+            e.target.parentElement.className += ` ${style.wrapperFocused}`;
+            /* eslint-enable no-param-reassign */
+            onFocus && onFocus();
+          }}
+          onBlur={e => {
+            e.target.parentElement.classList.remove(style.wrapperFocused);
+            onBlur && onBlur();
+          }}
+          placeholder={placeholder}
+          value={value}
+          maxLength={maxLength}
+        />
       </div>
     );
   }

--- a/src/components/TextArea/TextArea.jsx
+++ b/src/components/TextArea/TextArea.jsx
@@ -36,12 +36,7 @@ class TextArea extends Component {
     return (
       <div className={wrapperStyle} {...getDataAttrs(data)}>
         <textarea
-          ref={el => {
-            if (el && !el.props) {
-              new Autogrow(el);
-              this.props.parentRef && this.props.parentRef(el);
-            }
-          }}
+          ref={el => el && new Autogrow(el)}
           className={textareaStyle}
           disabled={disabled}
           onChange={onChange}

--- a/src/components/TextArea/style.scss
+++ b/src/components/TextArea/style.scss
@@ -51,7 +51,3 @@
 .disabled {
   @extend %input--disabled;
 }
-
-.counterStyle {
-  @extend %type--body;
-}

--- a/src/components/TextArea/style.scss
+++ b/src/components/TextArea/style.scss
@@ -51,3 +51,7 @@
 .disabled {
   @extend %input--disabled;
 }
+
+.counterStyle {
+  @extend %type--body;
+}

--- a/src/decorators/withCounter/withCounter.jsx
+++ b/src/decorators/withCounter/withCounter.jsx
@@ -2,57 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const withCounter = Component => {
-  return class extends Component {
+  return class extends React.Component {
     static propTypes = {
       value: PropTypes.string,
-      ref: PropTypes.function,
       counterStyle: PropTypes.object,
       maxLength: PropTypes.string,
     };
 
-    constructor(props) {
-      super(props);
-
-      this.state = {
-        value: props.value || '',
-      };
-    }
-
-    onChange = () => {
-      this.setState({
-        value: this.element.value || '',
-      });
-    };
-
     render() {
-      const props = {
-        ...this.props,
-        parentRef: el => {
-          if (el) {
-            this.element = el;
-          }
-        },
-        value: this.state.value,
-      };
-
-      if (props.onChange) {
-        props.onChange = (originalOnChange => {
-          return (...args) => {
-            this.onChange();
-            return originalOnChange(...args);
-          };
-        })(props.onChange);
-      } else {
-        props.onChange = this.onChange;
-      }
-
       return (
         <div>
-          <div>
-            {this.state.value.length}
+          <div className={this.props.counterStyle}>
+            {this.props.value ? this.props.value.length : 0}
             {this.props.maxLength && `/${this.props.maxLength}`} characters
           </div>
-          <Component {...props} />
+          <Component {...this.props} />
         </div>
       );
     }

--- a/src/decorators/withCounter/withCounter.jsx
+++ b/src/decorators/withCounter/withCounter.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const withCounter = Component => {
+  return class extends Component {
+    static propTypes = {
+      value: PropTypes.string,
+      ref: PropTypes.function,
+      counterStyle: PropTypes.object,
+      maxLength: PropTypes.string,
+    };
+
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        value: props.value || '',
+      };
+    }
+
+    onChange = () => {
+      this.setState({
+        value: this.element.value || '',
+      });
+    };
+
+    render() {
+      const props = {
+        ...this.props,
+        parentRef: el => {
+          if (el) {
+            this.element = el;
+          }
+        },
+        value: this.state.value,
+      };
+
+      if (props.onChange) {
+        props.onChange = (originalOnChange => {
+          return (...args) => {
+            this.onChange();
+            return originalOnChange(...args);
+          };
+        })(props.onChange);
+      } else {
+        props.onChange = this.onChange;
+      }
+
+      return (
+        <div>
+          <div>
+            {this.state.value.length}
+            {this.props.maxLength && `/${this.props.maxLength}`} characters
+          </div>
+          <Component {...props} />
+        </div>
+      );
+    }
+  };
+};
+
+export default withCounter;

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,8 @@ import FixedLeft from './components/layout/FixedLeft/FixedLeft';
 import FixedRight from './components/layout/FixedRight/FixedRight';
 import FixedTop from './components/layout/FixedTop/FixedTop';
 
+import withCounter from './decorators/withCounter/withCounter';
+
 import style from '../src/external';
 
 // Plasma object
@@ -116,4 +118,5 @@ export {
   TextArea,
   Tag,
   TimePicker,
+  withCounter,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,9 @@ import withCounter from './decorators/withCounter/withCounter';
 
 import style from '../src/external';
 
+const CountedTextArea = withCounter(TextArea);
+const CountedTextInput = withCounter(TextInput);
+
 // Plasma object
 
 const Plasma = {};
@@ -77,6 +80,8 @@ Plasma.FixedTop = FixedTop;
 Plasma.Toggle = Toggle;
 Plasma.Page = Page;
 Plasma.TimePicker = TimePicker;
+Plasma.CountedTextArea = CountedTextArea;
+Plasma.CountedTextInput = CountedTextInput;
 
 Plasma._style = style;
 
@@ -118,5 +123,6 @@ export {
   TextArea,
   Tag,
   TimePicker,
-  withCounter,
+  CountedTextArea,
+  CountedTextInput,
 };

--- a/stories/TextArea.js
+++ b/stories/TextArea.js
@@ -25,4 +25,23 @@ storiesOf('TextArea', module)
     <div>
       <TextArea maxLength="10" placeholder="Max length of 10" />
     </div>
+  ))
+  .add('withCounter', () => (
+    <div>
+      <TextArea withCounter placeholder="Should show a counter" />
+    </div>
+  ))
+  .add('withCounter and initial value', () => (
+    <div>
+      <TextArea withCounter placeholder="Should show a counter" value="foo bar" />
+    </div>
+  ))
+  .add('withCounter and maxLength', () => (
+    <div>
+      <TextArea
+        withCounter
+        maxLength="20"
+        placeholder="Should show a counter and have a max length"
+      />
+    </div>
   ));

--- a/stories/TextArea.js
+++ b/stories/TextArea.js
@@ -3,6 +3,9 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import TextArea from '../src/components/TextArea/TextArea';
+import withCounter from '../src/decorators/withCounter/withCounter';
+
+const TextAreaWithCounter = withCounter(TextArea);
 
 storiesOf('TextArea', module)
   .add('with div below', () => (
@@ -28,18 +31,17 @@ storiesOf('TextArea', module)
   ))
   .add('withCounter', () => (
     <div>
-      <TextArea withCounter placeholder="Should show a counter" />
+      <TextAreaWithCounter placeholder="Should show a counter" />
     </div>
   ))
   .add('withCounter and initial value', () => (
     <div>
-      <TextArea withCounter placeholder="Should show a counter" value="foo bar" />
+      <TextAreaWithCounter placeholder="Should show a counter" value="foo bar" />
     </div>
   ))
   .add('withCounter and maxLength', () => (
     <div>
-      <TextArea
-        withCounter
+      <TextAreaWithCounter
         maxLength="20"
         placeholder="Should show a counter and have a max length"
       />

--- a/stories/TextArea.jsx
+++ b/stories/TextArea.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
-import { linkTo } from '@storybook/addon-links';
 import TextArea from '../src/components/TextArea/TextArea';
 import withCounter from '../src/decorators/withCounter/withCounter';
+import StoryState from '../StoryState';
 
 const TextAreaWithCounter = withCounter(TextArea);
 
@@ -31,19 +30,28 @@ storiesOf('TextArea', module)
   ))
   .add('withCounter', () => (
     <div>
-      <TextAreaWithCounter placeholder="Should show a counter" />
-    </div>
-  ))
-  .add('withCounter and initial value', () => (
-    <div>
-      <TextAreaWithCounter placeholder="Should show a counter" value="foo bar" />
+      <StoryState
+        render={(state, setState) => (
+          <TextAreaWithCounter
+            placeholder="Should show a counter"
+            onChange={e => setState({ text: e.target.value })}
+            value={state.text}
+          />
+        )}
+      />
     </div>
   ))
   .add('withCounter and maxLength', () => (
     <div>
-      <TextAreaWithCounter
-        maxLength="20"
-        placeholder="Should show a counter and have a max length"
+      <StoryState
+        render={(state, setState) => (
+          <TextAreaWithCounter
+            maxLength="20"
+            placeholder="Should show a counter and have a max length"
+            onChange={e => setState({ text: e.target.value })}
+            value={state.text}
+          />
+        )}
       />
     </div>
   ));

--- a/stories/TextInput.jsx
+++ b/stories/TextInput.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { linkTo } from '@storybook/addon-links';
 import TextInput from '../src/components/TextInput/TextInput';
+import withCounter from '../src/decorators/withCounter/withCounter';
+import StoryState from '../StoryState';
+
+const TextInputWithCounter = withCounter(TextInput);
 
 storiesOf('TextInput', module).add('default', () => <TextInput onChange={action('changed')} />);
 
@@ -62,4 +65,29 @@ storiesOf('TextInput', module).add('clipping parent', () => (
 
 storiesOf('TextInput', module).add('max length', () => (
   <TextInput maxLength="10" onChange={action('changed')} />
+));
+
+storiesOf('TextInput', module).add('with counter', () => (
+  <StoryState
+    render={(state, setState) => (
+      <TextInputWithCounter
+        placeholder="Should show a counter"
+        onChange={e => setState({ text: e.target.value })}
+        value={state.text}
+      />
+    )}
+  />
+));
+
+storiesOf('TextInput', module).add('with counter and maxLength', () => (
+  <StoryState
+    render={(state, setState) => (
+      <TextInputWithCounter
+        placeholder="Should show a counter and have max length"
+        maxLength="20"
+        onChange={e => setState({ text: e.target.value })}
+        value={state.text}
+      />
+    )}
+  />
 ));


### PR DESCRIPTION
This makes textarea a controlled component and gives it a `withCounter` option (with ability to customize it via `counterStyle`)

### withCounter

<img width="335" alt="screenshot 2018-03-08 15 13 12" src="https://user-images.githubusercontent.com/383/37173995-42bf066c-22e3-11e8-80f9-eb40c6bd4778.png">

### withCounter + maxLength

<img width="287" alt="screenshot 2018-03-08 15 13 49" src="https://user-images.githubusercontent.com/383/37174019-509f6718-22e3-11e8-9d34-c0ff5c5f7196.png">
