### PR TITLE
Fix laggy text input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - "7"
+  - 8.9.3 
 before_script:
   - yarn global add gulp-cli
   - yarn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wework-dev/plasma",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wework-dev/plasma",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/components/TextArea/TextArea.jsx
+++ b/src/components/TextArea/TextArea.jsx
@@ -7,6 +7,10 @@ import Autogrow from './autogrow';
 import style from './style.scss';
 
 class TextArea extends Component {
+  setAutogrowRef = element => {
+    this.autogrowRef = new Autogrow(element);
+  };
+
   render() {
     const {
       data,
@@ -36,7 +40,7 @@ class TextArea extends Component {
     return (
       <div className={wrapperStyle} {...getDataAttrs(data)}>
         <textarea
-          ref={el => el && new Autogrow(el)}
+          ref={this.setAutogrowRef}
           className={textareaStyle}
           disabled={disabled}
           onChange={onChange}

--- a/src/components/TextArea/autogrow.js
+++ b/src/components/TextArea/autogrow.js
@@ -1,3 +1,5 @@
+import { throttle } from 'lodash';
+
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     define([], factory);
@@ -34,7 +36,7 @@
      * Sets textarea height as exact height of content
      * @returns {boolean}
      */
-    self.autogrowFn = function() {
+    self.autogrowFn = throttle(function() {
       var newHeight = 0,
         hasGrown = false;
       if ((textarea.scrollHeight - offset) > self.maxAllowedHeight) {
@@ -48,7 +50,7 @@
       }
       textarea.style.height = newHeight + 'px';
       return hasGrown;
-    };
+    }, 750);
 
     var offset = self.getOffset(textarea);
     self.rows = textarea.rows || 1;

--- a/src/components/TextArea/autogrow.js
+++ b/src/components/TextArea/autogrow.js
@@ -1,5 +1,3 @@
-import { throttle } from 'lodash';
-
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     define([], factory);
@@ -36,7 +34,7 @@ import { throttle } from 'lodash';
      * Sets textarea height as exact height of content
      * @returns {boolean}
      */
-    self.autogrowFn = throttle(function() {
+    self.autogrowFn = function() {
       var newHeight = 0,
         hasGrown = false;
       if ((textarea.scrollHeight - offset) > self.maxAllowedHeight) {
@@ -50,7 +48,7 @@ import { throttle } from 'lodash';
       }
       textarea.style.height = newHeight + 'px';
       return hasGrown;
-    }, 750);
+    };
 
     var offset = self.getOffset(textarea);
     self.rows = textarea.rows || 1;


### PR DESCRIPTION
Temp fix to try and reduce full document reflows by throttling the resizing of the textarea by 750ms