### PR TITLE
Update version script to build in prod mode

### DIFF
--- a/version.js
+++ b/version.js
@@ -15,7 +15,7 @@ fs.access('./dist/styles.css', fs.constants.R_OK, (err) => {
   }
 });
 
-const webpack = exec('webpack --config webpack.config.prod', (err, stdout, stderr) => {
+const webpack = exec('webpack --config webpack.config.prod -p', (err, stdout, stderr) => {
   if (err) {
     console.error(err);
   }


### PR DESCRIPTION
The README advises to run `yarn pack` when building a new version, which correctly runs `webpack --config webpack.config.prod -p`. 

However, those prod assets are overwritten when running `npm version patch`, which runs `webpack --config webpack.config.prod` during the `version` phase.

The `version` script is missing the `-p` flag, which is what signals to webpack to perform prod optimizations such as uglification and minification.